### PR TITLE
forced jpeg so python wouldn't bail

### DIFF
--- a/Contents/Server Plugin/plugin.py
+++ b/Contents/Server Plugin/plugin.py
@@ -253,7 +253,7 @@ class Plugin(indigo.PluginBase):
 		# Open the files in binary mode.  Let the MIMEImage class automatically
 		# guess the specific image type.
 		fp = open('/tmp/snap.jpg', 'rb')
-		img = MIMEImage(fp.read())
+		img = MIMEImage(fp.read(), "jpeg")
 		fp.close()
 		msg.attach(img)
 


### PR DESCRIPTION
i'll just throw this out there.  we expect a jpeg, and for some reason `MIMEImage` doesn't can't determine it, so its bailing.  it could be my py version, i'm on osx mavericks py 2.7.5

in any case, forcing to jpeg resolves it.
